### PR TITLE
Move countdownbar tokens from foundations to component

### DIFF
--- a/src/CountdownBar/Tokens/tokens.ts
+++ b/src/CountdownBar/Tokens/tokens.ts
@@ -1,0 +1,30 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  primary: {
+    color: inube.palette.blue.B400,
+  },
+  success: {
+    color: inube.palette.green.G400,
+  },
+  warning: {
+    color: inube.palette.yellow.Y400,
+  },
+  danger: {
+    color: inube.palette.red.R400,
+  },
+  help: {
+    color: inube.palette.purple.P400,
+  },
+  dark: {
+    color: inube.palette.neutral.N900,
+  },
+  gray: {
+    color: inube.palette.neutral.N20,
+  },
+  light: {
+    color: inube.palette.neutral.N10,
+  },
+};
+
+export { tokens };

--- a/src/CountdownBar/styles.js
+++ b/src/CountdownBar/styles.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { keyframes } from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const $CountdownBarAnimation = keyframes`
   0% {
@@ -18,8 +18,7 @@ const StyledCountdownBar = styled.div`
   animation: ${$CountdownBarAnimation} ${({ $duration }) => $duration}ms linear;
   background-color: ${({ theme, $appearance }) => {
     return (
-      theme?.countdownBar?.[$appearance]?.color ||
-      inube.countdownBar[$appearance].color
+      theme?.countdownBar?.[$appearance]?.color || tokens[$appearance].color
     );
   }};
   animation-fill-mode: forwards;


### PR DESCRIPTION
This PR relocates the countdownbar tokens from the foundations folder to the component folder, updating all necessary imports to align with the new structure and ensuring that components are referencing the correct token paths. This change improves the overall organization, maintainability, and clarity of the codebase.